### PR TITLE
Add method length check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,31 @@
+# =====================================================================================
+# Default owners for the entire repo
+# This section MUST be first
+# =====================================================================================
+
+* @folio-org/eureka
+
+#######################################################################################
+#
+# Entries below this section, if matched, will take precedence over the default owners.
+#
+# Pattern matching reference:
+# https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file
+# https://git-scm.com/docs/gitignore#_pattern_format
+#
+#######################################################################################
+
+# =====================================================================================
+#
+# Contracts:
+#
+# Additional Contracts should be added in a new
+# section with a comment block listing the dependant
+# service.
+#
+# Add owners to patterns with the following syntax:
+#   "@owningTeam @folio-org/team"
+#
+# The default team for this repo MUST be listed in your owners entry.
+#
+# =====================================================================================

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,6 @@
+### **Purpose**
+Explain why these changes are needed and link the related issue (e.g., https://folio-org.atlassian.net/browse/PROJ-123).
+
+### **Approach**
+Provide a brief technical summary of the changes.
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      dev-deps:
+        dependency-type: "development"
+      prod-deps:
+        dependency-type: "production"

--- a/src/main/resources/folio-checkstyle/checkstyle.xml
+++ b/src/main/resources/folio-checkstyle/checkstyle.xml
@@ -348,6 +348,10 @@
       <message key="name.invalidPattern"
                value="Method name ''{0}'' must match pattern ''{1}''."/>
     </module>
+    <module name="MethodLength">
+      <property name="max" value="${checkstyle.method-length.max}" default="25"/>
+      <property name="countEmpty" value="false"/>
+    </module>
     <module name="SingleLineJavadoc">
       <property name="ignoreInlineTags" value="false"/>
     </module>


### PR DESCRIPTION
### **Purpose**
Add [MethodLength](https://checkstyle.sourceforge.io/checks/sizes/methodlength.html#MethodLength) to control the length of methods. This should force developers to write more concise methods that are easy to understand. Therefore, long methods should usually be refactored into several individual methods that focus on a specific task. 

### **Approach**
* add a rule with default value = `25` and a possibility to override it in a project via `checkstyle.method-length.max` property